### PR TITLE
Fix #48 - apply ipv4 CIDR access list when compiled with ipv6 support

### DIFF
--- a/conserver/access.c
+++ b/conserver/access.c
@@ -67,9 +67,9 @@ AddrCmp(struct in_addr *addr, char *pattern)
     in_addr_t hostaddr, pattern_addr, netmask;
     char *p, *slash_posn;
     static STRING *buf = (STRING *)0;
-# if HAVE_INET_ATON
+#if HAVE_INET_ATON
     struct in_addr inetaddr;
-# endif
+#endif
 
     if (buf == (STRING *)0)
 	buf = AllocString();
@@ -82,15 +82,15 @@ AddrCmp(struct in_addr *addr, char *pattern)
     } else
 	p = pattern;
 
-# if HAVE_INET_ATON
+#if HAVE_INET_ATON
     if (inet_aton(p, &inetaddr) == 0)
 	return 1;
     pattern_addr = inetaddr.s_addr;
-# else
+#else
     pattern_addr = inet_addr(p);
     if (pattern_addr == (in_addr_t) (-1))
 	return 1;		/* malformed address */
-# endif
+#endif
 
     if (slash_posn) {
 	/* convert explicit netmask */
@@ -164,13 +164,15 @@ AccType(INADDR_STYPE *addr, char **peername)
     for (pACtmp = pACList; pACtmp != (ACCESS *)0; pACtmp = pACtmp->pACnext) {
 	CONDDEBUG((1, "AccType(): who=%s, trust=%c", pACtmp->pcwho,
 		   pACtmp->ctrust));
-        if (addr->ss_family == AF_INET && pACtmp->isCIDR != 0) {
-            if (AddrCmp(&(((struct sockaddr_in *)addr)->sin_addr), pACtmp->pcwho) == 0) {
-                ret = pACtmp->ctrust;
-                goto common_ret;
-            }
-            continue;
-        }
+	if (addr->ss_family == AF_INET && pACtmp->isCIDR != 0) {
+	    if (AddrCmp
+		(&(((struct sockaddr_in *)addr)->sin_addr),
+		 pACtmp->pcwho) == 0) {
+		ret = pACtmp->ctrust;
+		goto common_ret;
+	    }
+	    continue;
+	}
 
 	if (strstr(ipaddr, pACtmp->pcwho) != NULL) {
 	    CONDDEBUG((1, "AccType(): match for ip=%s", ipaddr));

--- a/conserver/access.c
+++ b/conserver/access.c
@@ -49,7 +49,6 @@
 # include <netdb.h>
 #endif
 
-#if !USE_IPV6
 /* Compare an Internet address (IPv4 expected), with an address pattern
  * passed as a character string representing an address in the Internet
  * standard `.' notation, optionally followed by a slash and an integer
@@ -120,7 +119,6 @@ AddrCmp(struct in_addr *addr, char *pattern)
 	       pattern_addr & netmask, pattern_addr, netmask));
     return (hostaddr & netmask) != (pattern_addr & netmask);
 }
-#endif /* USE_IPV6 */
 
 /* return the access type for a given host entry			(ksb)
  */
@@ -166,6 +164,13 @@ AccType(INADDR_STYPE *addr, char **peername)
     for (pACtmp = pACList; pACtmp != (ACCESS *)0; pACtmp = pACtmp->pACnext) {
 	CONDDEBUG((1, "AccType(): who=%s, trust=%c", pACtmp->pcwho,
 		   pACtmp->ctrust));
+        if (addr->ss_family == AF_INET && pACtmp->isCIDR != 0) {
+            if (AddrCmp(&(((struct sockaddr_in *)addr)->sin_addr), pACtmp->pcwho) == 0) {
+                ret = pACtmp->ctrust;
+                goto common_ret;
+            }
+            continue;
+        }
 
 	if (strstr(ipaddr, pACtmp->pcwho) != NULL) {
 	    CONDDEBUG((1, "AccType(): match for ip=%s", ipaddr));

--- a/conserver/consent.c
+++ b/conserver/consent.c
@@ -885,7 +885,7 @@ ConsInit(CONSENT *pCE)
 #if HAVE_SETSOCKOPT
 		int one = 1;
 #endif
-		Sleep(100000); /* Not all terminal servers can keep up */
+		Sleep(100000);	/* Not all terminal servers can keep up */
 
 #if USE_IPV6
 # if HAVE_MEMSET
@@ -933,7 +933,7 @@ ConsInit(CONSENT *pCE)
 
 			ret = connect(cofile, rp->ai_addr, rp->ai_addrlen);
 			if (ret == 0 || errno == EINPROGRESS)
-				goto success;
+			    goto success;
 
 		      fail:
 			close(cofile);

--- a/conserver/cutil.c
+++ b/conserver/cutil.c
@@ -3096,7 +3096,7 @@ void
 Sleep(useconds_t usec)
 {
 #ifdef HAVE_NANOSLEEP
-    struct timespec ts = {0, usec * 1000};
+    struct timespec ts = { 0, usec * 1000 };
     nanosleep(&ts, NULL);
 #else
     usleep(usec);

--- a/conserver/group.c
+++ b/conserver/group.c
@@ -5102,7 +5102,7 @@ Spawn(GRPENT *pGE, int msfd)
 		hints.ai_flags =
 		    AI_PASSIVE | AI_NUMERICHOST | AI_NUMERICSERV;
 		snprintf(serv, sizeof(serv), "%hu",
-			 bindBasePort + portInc);
+			 (short)(bindBasePort + portInc));
 		error = getaddrinfo(host, serv, &hints, &res);
 		if (error)
 		    goto OUT;

--- a/conserver/group.c
+++ b/conserver/group.c
@@ -5250,7 +5250,7 @@ Spawn(GRPENT *pGE, int msfd)
 	     * possibly opens another socket to the port.  this really is only
 	     * an issue if you use the same port with -p and -b, i think.
 	     */
-	    Sleep(750000); /* pause 0.75 sec to throttle startup a bit */
+	    Sleep(750000);	/* pause 0.75 sec to throttle startup a bit */
 	    pGE->pid = pid;
 	    return;
 	case 0:

--- a/console/console.c
+++ b/console/console.c
@@ -1473,11 +1473,11 @@ CallUp(CONSFILE *pcf, char *pcMaster, char *pcMach, char *pcHow,
     FilePrint(pcf, FLAGFALSE, "%c%c=", chAttn, chEsc);
     r = ReadReply(pcf, FLAGFALSE);
     if (strncmp(r, "[unknown", 8) != 0 && strncmp(r, "[up]", 4) != 0) {
-	    FileWrite(cfstdout, FLAGFALSE, r, -1);
-	    if (config->exitdown == FLAGTRUE) {
-		    Error("Console is not 'up'. Exiting. (-k)");
-		    Bye(EX_UNAVAILABLE);
-	    }
+	FileWrite(cfstdout, FLAGFALSE, r, -1);
+	if (config->exitdown == FLAGTRUE) {
+	    Error("Console is not 'up'. Exiting. (-k)");
+	    Bye(EX_UNAVAILABLE);
+	}
     }
 
     /* try to grok the version of the server */
@@ -2041,7 +2041,7 @@ main(int argc, char **argv)
 		pcCmd = "info";
 		break;
 
-	case 'k':
+	    case 'k':
 		optConf->exitdown = FLAGTRUE;
 		break;
 


### PR DESCRIPTION
While this addresses the immediate problem, there also seems to be lack of support for the `--with-trustrevdns` when `--with-ipv6` is used.  So, this isn't perfect, but gets things closer.