### PR TITLE
configure.ac: autoconf-2.70 fix

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -30,11 +30,11 @@ AH_TEMPLATE([TRUST_UDS_CRED], [Defined if we trust credentials from UDS client])
 
 dnl ### Normal initialization. ######################################
 AC_INIT([conserver],m4_esyscmd_s([./gen-version number]))
-AC_PREREQ(2.59)
+AC_PREREQ(2.69)
 AC_CONFIG_SRCDIR([conserver/main.c])
 AC_CONFIG_HEADER(config.h)
 
-AC_DEFINE_UNQUOTED(CONFIGINVOCATION, "$0 $@")
+AC_DEFINE_UNQUOTED(CONFIGINVOCATION, "$0 $*")
 
 dnl ### Set some option defaults. ###################################
 if test -z "$CFLAGS"; then


### PR DESCRIPTION
This was previously reported downstream at Gentoo: https://bugs.gentoo.org/750230

autoconf-2.70 changed behavior when using `$@` in `AC_DEFINE_UNQUOTED` which results in the string getting a newline after each element and that later makes the configure run fail. Changing this to `$*` fixes the issue.

The change to `AC_PREREQ` is not really required for autoconf-2.70 (especially not settiong it to `2.69` vaule) but I could only test the fix with autoconf-2.69 and autoconf-2.70 and given that v2.69 is nearly eight years old already I don't see a problem in rasing the version requirement here.