### PR TITLE
conserver-server: add more missing high baud rates

### DIFF
--- a/conserver/consent.c
+++ b/conserver/consent.c
@@ -104,6 +104,21 @@ BAUD baud[] = {
 # if defined(B1500000)
     {"1500000", B1500000},
 # endif
+# if defined(B1000000)
+    {"1000000", B1000000},
+# endif
+# if defined(B921600)
+    {"921600", B921600},
+# endif
+# if defined(B500000)
+    {"500000", B500000},
+# endif
+# if defined(B460800)
+    {"460800", B460800},
+# endif
+# if defined(B230400)
+    {"230400", B230400},
+# endif
 # if defined(B1152000)
     {"1152000", B1152000},
 # endif


### PR DESCRIPTION
For as long as we support fixed baud rates fill in more gaps left
after e7ca230c2239735d1b4c05747da8efbbae2fb547 supported by various
operating systems.