### PR TITLE
Make compile --with-ipv6 & setproctitle

### DIFF
--- a/conserver/main.c
+++ b/conserver/main.c
@@ -1770,7 +1770,7 @@ main(int argc, char **argv)
 		remote++;
 	    setproctitle("master: port %hu, %d local, %d remote",
 # if USE_IPV6
-			 config->primaryport,
+			 (unsigned short)strtol(config->primaryport, NULL, 10),
 # elif USE_UNIX_DOMAIN_SOCKETS
 			 (unsigned short)0,
 # else

--- a/conserver/readcfg.c
+++ b/conserver/readcfg.c
@@ -5374,7 +5374,12 @@ ReReadCfg(int fd, int msfd)
 		local += pGE->imembers;
 	    for (pRC = pRCList; (REMOTE *)0 != pRC; pRC = pRC->pRCnext)
 		remote++;
-	    setproctitle("master: port %hu, %d local, %d remote", bindPort,
+	    setproctitle("master: port %hu, %d local, %d remote",
+# if !USE_UNIX_DOMAIN_SOCKETS
+			 (unsigned short)strtol(config->primaryport, NULL, 10),
+# else
+			 (unsigned short)0,
+# endif
 			 local, remote);
 	} else
 	    setproctitle("group %u: port %hu, %d %s", pGroups->id,


### PR DESCRIPTION
If compiling with IPv6 support and setproctitle two places are using
the wrong type (char *) instead of (ushort) or a non-existent variable.
Fix these to make --with-ipv6 compile on FreeBSD.