### PR TITLE
conserver.cf: devicesubst add 'b' for baud rate

### DIFF
--- a/conserver.cf/conserver.cf.man.in
+++ b/conserver.cf/conserver.cf.man.in
@@ -540,6 +540,10 @@ value
 .PP
 Numeric Replacement
 .TP
+.B b
+.B baud
+value
+.TP
 .B p
 config
 .B port

--- a/conserver/readcfg.c
+++ b/conserver/readcfg.c
@@ -997,6 +997,9 @@ SubstValue(char c, char **s, int *i)
 	} else if (c == 'P') {
 	    (*i) = pCE->netport;
 	    retval = 1;
+	} else if (c == 'b') {
+	    (*i) = pCE->baud->irate;
+	    retval = 1;
 	}
     }
 
@@ -1009,6 +1012,7 @@ SubstToken(char c)
     switch (c) {
 	case 'p':
 	case 'P':
+	case 'b':
 	    substTokenCount[(unsigned)c]++;
 	    return ISNUMBER;
 	case 'h':


### PR DESCRIPTION
Add a 'b' subst format to get baud rate numbers as well to build
up device names and the others.