### PR TITLE
conserver.cf: devicesubst add 'b' for baud rate

### DIFF
--- a/conserver.cf/conserver.cf.man.in
+++ b/conserver.cf/conserver.cf.man.in
@@ -540,6 +540,10 @@ value
 .PP
 Numeric Replacement
 .TP
+.B b
+.B baud
+value
+.TP
 .B p
 config
 .B port

--- a/conserver/readcfg.c
+++ b/conserver/readcfg.c
@@ -987,6 +987,13 @@ SubstValue(char c, char **s, int *i)
 		(*s) = pCE->replstring;
 	    }
 	    retval = 1;
+	} else if (c == 'b') {
+	    if (pCE->baud == NULL || pCE->baud->acrate == (char *)0) {
+		(*s) = empty;
+	    } else {
+		(*s) = pCE->baud->acrate;
+	    }
+	    retval = 1;
 	}
     }
 
@@ -1013,6 +1020,7 @@ SubstToken(char c)
 	    return ISNUMBER;
 	case 'h':
 	case 'c':
+	case 'b':
 	case 'r':
 	    substTokenCount[(unsigned)c]++;
 	    return ISSTRING;


### PR DESCRIPTION
Add a 'b' subst format to get baud rates as well to build up
device names and the others.