### PR TITLE
conserver: reflect that baud rates have increased to 7 digits

### DIFF
--- a/conserver.cf/conserver.cf.man.in
+++ b/conserver.cf/conserver.cf.man.in
@@ -468,7 +468,7 @@ all consoles have an implicit ``include "*";'' at the beginning
 of their definition).
 .RS
 .TP
-\f3baud\fP \f3300\fP|\f3600\fP|\f31800\fP|\f32400\fP|\f34800\fP|\f39600\fP|\f319200\fP|\f338400\fP|\f357600\fP|\f3115200\fP
+\f3baud\fP \f3300\fP|\f3600\fP|\f31800\fP|\f32400\fP|\f34800\fP|\f39600\fP|\f319200\fP|\f338400\fP|\f357600\fP|\f3115200\fP|..|\f34000000\fP
 .br
 Assign the baud rate to the console.
 Only consoles of type ``device'' will use this value.

--- a/conserver/group.c
+++ b/conserver/group.c
@@ -2210,7 +2210,7 @@ CommandExamine(GRPENT *pGE, CONSCLIENT *pCLServing, CONSENT *pCEServing,
 		break;
 	}
 	FilePrint(pCLServing->fd, FLAGFALSE,
-		  " %-24.24s on %-32.32s at %6.6s%c\r\n", pCE->server, d,
+		  " %-24.24s on %-32.32s at %7.7s%c\r\n", pCE->server, d,
 		  b, p);
 	if (args != (char *)0)
 	    break;

--- a/test/results/test13
+++ b/test/results/test13
@@ -1,3 +1,3 @@
- shellb                   on at  Local 
- shella                   on at  Local 
- shell                    on at  Local 
+ shellb                   on at   Local 
+ shella                   on at   Local 
+ shell                    on at   Local 

--- a/test/results/test15
+++ b/test/results/test15
@@ -1,1 +1,1 @@
- shell                    on at  Local 
+ shell                    on at   Local 


### PR DESCRIPTION
When having "examine" print baud/parity increase the maximum string
width from 6 to 7 digits.  And while here try to indicate more baud
values in the manual going up to 4000000.