### PR TITLE
configure.ac: support libgssapi_krb5

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -638,7 +638,17 @@ AC_ARG_WITH(gssapi,
 			cons_with_gssapi="YES"
 			AC_DEFINE(HAVE_GSSAPI)
 			have_gssapi=yes],
-			[AC_MSG_RESULT(no)])])])],)
+			[AC_MSG_RESULT(no)
+			LIBS="$oLIBS -lgssapi_krb5"
+			AC_MSG_CHECKING(for gssapi library -lgssapi_krb5)
+			AC_TRY_LINK([#include <gssapi/gssapi.h>
+			],[gss_create_empty_oid_set(NULL, NULL)],
+			[AC_MSG_RESULT(yes)
+			cons_with_gssapi="YES"
+			AC_DEFINE(HAVE_GSSAPI)
+			have_gssapi=yes],
+			[AC_MSG_RESULT(no)])])])])],)
+
 
 	if test $have_gssapi = no; then
 	    LIBS="$oLIBS"


### PR DESCRIPTION
This PR tries to upstream a patch used by Fedora for many years that adds a support for `libgssapi_krb5`.

Fixes: #59