### PR TITLE
Don't reference `true`

### DIFF
--- a/conserver/group.c
+++ b/conserver/group.c
@@ -5038,7 +5038,7 @@ Spawn(GRPENT *pGE, int msfd)
     struct sockaddr_in lstn_port;
 # endif
 # if HAVE_SETSOCKOPT
-    int true = 1;
+    int sock_opt_true = 1;
 # endif
     unsigned short portInc = 0;
 #else
@@ -5065,8 +5065,8 @@ Spawn(GRPENT *pGE, int msfd)
 	}
 # if HAVE_SETSOCKOPT
 	if (setsockopt
-	    (sfd, SOL_SOCKET, SO_REUSEADDR, (char *)&true,
-	     sizeof(true)) < 0) {
+	    (sfd, SOL_SOCKET, SO_REUSEADDR, (char *)&sock_opt_true,
+	     sizeof(sock_opt_true)) < 0) {
 	    Error("Spawn(): setsockopt(%u,SO_REUSEADDR): %s", sfd,
 		  strerror(errno));
 	    return;
@@ -5197,7 +5197,7 @@ Spawn(GRPENT *pGE, int msfd)
     }
 # if HAVE_SETSOCKOPT
     if (setsockopt
-	(sfd, SOL_SOCKET, SO_REUSEADDR, (char *)&true, sizeof(true))
+	(sfd, SOL_SOCKET, SO_REUSEADDR, (char *)&sock_opt_true, sizeof(sock_opt_true))
 	< 0) {
 	Error("Spawn(): setsockopt(%u,SO_REUSEADDR): %s", sfd,
 	      strerror(errno));

--- a/conserver/master.c
+++ b/conserver/master.c
@@ -690,7 +690,7 @@ Master(void)
     struct sockaddr_in master_port;
 # endif
 # if HAVE_SETSOCKOPT
-    int true = 1;
+    int sock_opt_true = 1;
 # endif
 #else
     struct sockaddr_un master_port;
@@ -750,8 +750,8 @@ Master(void)
 
 # if HAVE_SETSOCKOPT
 	if (setsockopt
-	    (msfd, SOL_SOCKET, SO_REUSEADDR, (char *)&true,
-	     sizeof(true)) < 0)
+	    (msfd, SOL_SOCKET, SO_REUSEADDR, (char *)&sock_opt_true,
+	     sizeof(sock_opt_true)) < 0)
 	    goto fail;
 # endif
 	if (!SetFlags(msfd, O_NONBLOCK, 0))
@@ -821,8 +821,8 @@ Master(void)
     }
 # if HAVE_SETSOCKOPT
     if (setsockopt
-	(msfd, SOL_SOCKET, SO_REUSEADDR, (char *)&true,
-	 sizeof(true)) < 0) {
+	(msfd, SOL_SOCKET, SO_REUSEADDR, (char *)&sock_opt_true,
+	 sizeof(sock_opt_true)) < 0) {
 	Error("Master(): setsockopt(%u,SO_REUSEADDR): %s", msfd,
 	      strerror(errno));
 	return;


### PR DESCRIPTION
`true` coming from some macos configurations is a define in `stdbool`. This
means it can't be redefined or turned into a reference.

Use a different variable name.