### PR TITLE
Fix failure of out-of-tree build

### DIFF
--- a/conserver/Makefile.in
+++ b/conserver/Makefile.in
@@ -1,6 +1,7 @@
 ### Path settings
 datarootdir = @datarootdir@
 srcdir = @srcdir@
+VPATH = @srcdir@
 top_srcdir = @top_srcdir@
 prefix = @prefix@
 exec_prefix = @exec_prefix@

--- a/console/Makefile.in
+++ b/console/Makefile.in
@@ -1,6 +1,7 @@
 ### Path settings
 datarootdir = @datarootdir@
 srcdir = @srcdir@
+VPATH = @srcdir@
 top_srcdir = @top_srcdir@
 prefix = @prefix@
 exec_prefix = @exec_prefix@


### PR DESCRIPTION
Currently out-of-tree build fails:

mkdir build-conserver               
cd build-conserver                  
../conserver-8.2.7/configure
make

gcc -O  -o conserver access.o client.o consent.o group.o main.o master.o readcfg.o fallback.o cutil.o -lutil -lcrypt  
/usr/bin/ld: cannot find access.o: No such file or directory
/usr/bin/ld: cannot find client.o: No such file or directory
/usr/bin/ld: cannot find consent.o: No such file or directory
/usr/bin/ld: cannot find group.o: No such file or directory
/usr/bin/ld: cannot find main.o: No such file or directory
/usr/bin/ld: cannot find master.o: No such file or directory
/usr/bin/ld: cannot find readcfg.o: No such file or directory
/usr/bin/ld: cannot find fallback.o: No such file or directory
/usr/bin/ld: cannot find cutil.o: No such file or directory
collect2: error: ld returned 1 exit status
make[1]: *** [Makefile:48: conserver] Error 1

Add VPATH to Makefile.in according to https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Build-Directories.html