### PR TITLE
In AddrsMatch, keep copies of addrinfos to free.

### DIFF
--- a/conserver/consent.c
+++ b/conserver/consent.c
@@ -1308,7 +1308,7 @@ AddrsMatch(char *addr1, char *addr2)
 {
 #if USE_IPV6
     int error, ret = 0;
-    struct addrinfo *ai1, *ai2, hints;
+    struct addrinfo *ai1, *ai2, *rp1, *rp2, hints;
 #else
     /* so, since we might use inet_addr, we're going to use
      * (in_addr_t)(-1) as a sign of an invalid ip address.
@@ -1346,17 +1346,19 @@ AddrsMatch(char *addr1, char *addr2)
 	goto done;
     }
 
-    for (; ai1 != NULL; ai1 = ai1->ai_next) {
-	for (; ai2 != NULL; ai2 = ai2->ai_next) {
-	    if (ai1->ai_addr->sa_family != ai2->ai_addr->sa_family)
+    rp1 = ai1;
+    rp2 = ai2;
+    for (; rp1 != NULL; rp1 = rp1->ai_next) {
+	for (; rp2 != NULL; rp2 = rp2->ai_next) {
+	    if (rp1->ai_addr->sa_family != rp2->ai_addr->sa_family)
 		continue;
 
 	    if (
 # if HAVE_MEMCMP
-		   memcmp(&ai1->ai_addr, &ai2->ai_addr,
+		   memcmp(&rp1->ai_addr, &rp2->ai_addr,
 			  sizeof(struct sockaddr_storage))
 # else
-		   bcmp(&ai1->ai_addr, &ai2->ai_addr,
+		   bcmp(&rp1->ai_addr, &rp2->ai_addr,
 			sizeof(struct sockaddr_storage))
 # endif
 		   == 0) {


### PR DESCRIPTION
When looping through addrinfo lists matching addresses, keep a copy of the original addrinfo pointers to free instead of ending up at the terminating NULLs and trying to free those.

In the best case this fixes a mem leak.  In implementations such as musl where freeaddrinfo(NULL) is not safe (which is not required by the spec), this fixes a segfault.

(I used the "rp" names to be consistent with other similar loops elsewhere in the code.)