### PR TITLE
conserver.cf: second resolution for reinitcheck

### DIFF
--- a/conserver.cf/conserver.cf.man.in
+++ b/conserver.cf/conserver.cf.man.in
@@ -385,11 +385,14 @@ Turn redirection on or off (see the
 .B \-R
 command-line flag).
 .TP
-\f3reinitcheck\fP \f2number\fP
+\f3reinitcheck\fP \f2number\fP[\f3s\fP|\f3m\fP]
 .br
 Set the number of minutes used between reinitialization checks (see the
 .B \-O
 command-line flag).
+If an `s' or `m' is used after
+.IR number ,
+the specified time is interpreted as seconds or minutes.
 .TP
 \f3secondaryport\fP \f2number\fP|\f2name\fP
 .br

--- a/conserver/group.c
+++ b/conserver/group.c
@@ -1023,7 +1023,7 @@ ReUp(GRPENT *pGE, short automatic)
     /* update all the timers */
     if (automatic == 0 || automatic == 2) {
 	if (config->reinitcheck)
-	    timers[T_REINIT] = tyme + (config->reinitcheck * 60);
+	    timers[T_REINIT] = tyme + config->reinitcheck;
     }
     if (!fNoautoreup)
 	timers[T_AUTOUP] = tyme + 60;

--- a/conserver/main.c
+++ b/conserver/main.c
@@ -1365,7 +1365,7 @@ main(int argc, char **argv)
 		break;
 	    case 'O':
 		/* How often to try opening all down consoles, in minutes */
-		optConf->reinitcheck = atoi(optarg);
+		optConf->reinitcheck = atoi(optarg) * 60;
 		break;
 	    case 'p':
 		if ((optConf->primaryport = StrDup(optarg)) == (char *)0)

--- a/conserver/readcfg.c
+++ b/conserver/readcfg.c
@@ -4562,6 +4562,7 @@ void
 ConfigItemReinitcheck(char *id)
 {
     char *p;
+    int factor = 0;
 
     CONDDEBUG((1, "ConfigItemReinitcheck(%s) [%s:%d]", id, file, line));
 
@@ -4570,18 +4571,22 @@ ConfigItemReinitcheck(char *id)
 	return;
     }
 
-    for (p = id; *p != '\000'; p++)
-	if (!isdigit((int)(*p)))
+    for (p = id; factor == 0 && *p != '\000'; p++)
+	if (*p == 's' || *p == 'S')
+	    factor = 1;
+	else if (*p == 'm' || *p == 'M')
+	    factor = 60;
+	else if (!isdigit((int)(*p)))
 	    break;
 
-    /* if it wasn't a number */
+    /* if it wasn't a number or a qualifier wasn't at the end */
     if (*p != '\000') {
 	if (isMaster)
 	    Error("invalid reinitcheck value `%s' [%s:%d]", id, file,
 		  line);
 	return;
     }
-    parserConfigTemp->reinitcheck = atoi(id);
+    parserConfigTemp->reinitcheck = atoi(id) * (factor == 0 ? 60 : factor);
 }
 
 void

--- a/conserver/readcfg.h
+++ b/conserver/readcfg.h
@@ -18,7 +18,7 @@ typedef struct config {
     char *primaryport;
     FLAG redirect;
     FLAG loghostnames;
-    int reinitcheck;
+    int reinitcheck; /* stored in sec, configured in min or sec */
     char *secondaryport;
     char *unifiedlog;
     int initdelay;

--- a/test/test1.cf
+++ b/test/test1.cf
@@ -7,6 +7,9 @@ default * {
 	timestamp "";
 	include full;
 }
+config * {
+	reinitcheck 1s;
+}
 break 5 {
 	string "\rtest\r";
 }


### PR DESCRIPTION
Add support for specifying `reinitcheck` in seconds instead of default minutes. If no unit is specified, minutes are used for backward compatibility.

Rationale:
If target system comes from down to up sometimes waiting for >1min to reinit the connection is not acceptable as some early boot messages or prompts can be lost.