### PR TITLE
Improved execSlave printing...

### DIFF
--- a/conserver/consent.c
+++ b/conserver/consent.c
@@ -798,6 +798,8 @@ ConsDown(CONSENT *pCE, FLAG downHard, FLAG force)
     if (pCE->type == EXEC && pCE->execSlaveFD != 0) {
 	close(pCE->execSlaveFD);
 	pCE->execSlaveFD = 0;
+	free(pCE->execSlave);
+	pCE->execSlave = NULL;
     }
     pCE->fup = 0;
     pCE->nolog = 0;

--- a/conserver/group.c
+++ b/conserver/group.c
@@ -2175,7 +2175,7 @@ CommandExamine(GRPENT *pGE, CONSCLIENT *pCLServing, CONSENT *pCEServing,
 	char p = '\000';
 	switch (pCE->type) {
 	    case EXEC:
-		d = pCE->execSlave;
+		d = (pCE->execSlaveFD > 0) ? pCE->execSlave : "(inactive)";
 		b = "Local";
 		p = ' ';
 		break;
@@ -2343,7 +2343,8 @@ CommandInfo(GRPENT *pGE, CONSCLIENT *pCLServing, CONSENT *pCEServing,
 	    case EXEC:
 		FilePrint(pCLServing->fd, FLAGTRUE, "|:%s,%lu,%s,%d:",
 			  (pCE->exec != (char *)0 ? pCE->exec : "/bin/sh"),
-			  (unsigned long)pCE->ipid, pCE->execSlave,
+			  (unsigned long)pCE->ipid,
+			  (pCE->execSlaveFD > 0) ? pCE->execSlave : "(inactive)",
 			  FileFDNum(pCE->cofile));
 		break;
 #if HAVE_FREEIPMI


### PR DESCRIPTION
Show "(inactive)" rather than an invalid pty device name for ondemand consoles that are closed.
Show "(inactive)" rather than "(null)" for ondemand consoles that have never been opened.

For more detail see issue 105:  https://github.com/bstansell/conserver/issues/105