### PR TITLE
Prevent spy-mode clients (i.e., console -s ...) from being promoted to console writer

### DIFF
--- a/conserver/group.c
+++ b/conserver/group.c
@@ -3242,7 +3242,6 @@ DoClientRead(GRPENT *pGE, CONSCLIENT *pCLServing)
 			    TagLogfileAct(pCEServing, "%s attached",
 					  pCLServing->acid->string);
 			} else {
-			    ClientWantsWrite(pCLServing);
 			    FileWrite(pCLServing->fd, FLAGFALSE,
 				      "[spy]\r\n", -1);
 			}
@@ -3789,7 +3788,9 @@ DoClientRead(GRPENT *pGE, CONSCLIENT *pCLServing)
 
 			    case 'c':
 				if (!pCLServing->fwr) {
-				    goto unknownchar;
+				    FileWrite(pCLServing->fd, FLAGFALSE,
+					      "attach to toggle flow control]\r\n", -1);
+				    continue;
 				}
 				CommandChangeFlow(pGE, pCLServing,
 						  pCEServing, tyme);
@@ -3797,7 +3798,9 @@ DoClientRead(GRPENT *pGE, CONSCLIENT *pCLServing)
 
 			    case 'd':	/* down a console       */
 				if (!pCLServing->fwr) {
-				    goto unknownchar;
+				    FileWrite(pCLServing->fd, FLAGFALSE,
+					      "attach to down console]\r\n", -1);
+				    continue;
 				}
 				CommandDown(pGE, pCLServing, pCEServing,
 					    tyme);
@@ -3836,7 +3839,9 @@ DoClientRead(GRPENT *pGE, CONSCLIENT *pCLServing)
 
 			    case 'L':
 				if (!pCLServing->fwr) {
-				    goto unknownchar;
+				    FileWrite(pCLServing->fd, FLAGFALSE,
+					      "attach to toggle logging]\r\n", -1);
+				    continue;
 				}
 				CommandLogging(pGE, pCLServing, pCEServing,
 					       tyme);
@@ -3844,7 +3849,9 @@ DoClientRead(GRPENT *pGE, CONSCLIENT *pCLServing)
 
 			    case 'l':	/* halt character 1     */
 				if (!pCLServing->fwr) {
-				    goto unknownchar;
+				    FileWrite(pCLServing->fd, FLAGFALSE,
+					      "attach to send break]\r\n", -1);
+				    continue;
 				}
 				if (pCEServing->fronly) {
 				    FileWrite(pCLServing->fd, FLAGFALSE,
@@ -3923,10 +3930,12 @@ DoClientRead(GRPENT *pGE, CONSCLIENT *pCLServing)
 				break;
 
 			    case 's':	/* spy mode */
-				if (!pCLServing->fwr) {
-				    goto unknownchar;
-				}
 				pCLServing->fwantwr = 0;
+				if (!pCLServing->fwr) {
+				    FileWrite(pCLServing->fd, FLAGFALSE,
+					      "ok]\r\n", -1);
+				    continue;
+				}
 				BumpClient(pCEServing, (char *)0);
 				TagLogfileAct(pCEServing, "%s detached",
 					      pCLServing->acid->string);
@@ -3988,7 +3997,9 @@ DoClientRead(GRPENT *pGE, CONSCLIENT *pCLServing)
 
 			    case '!':	/* invoke a task */
 				if (!pCLServing->fwr) {
-				    goto unknownchar;
+				    FileWrite(pCLServing->fd, FLAGFALSE,
+					      "attach to invoke task]\r\n", -1);
+				    continue;
 				}
 				pCLServing->iState = S_TASK;
 				FileWrite(pCLServing->fd, FLAGFALSE,


### PR DESCRIPTION
This patch prevents console clients started explicitly in spy mode (e.g., console -s victim) from being promoted to console writer after a preexisting writer disconnects.  It also makes the server produce more useful error messages when issued commands that cannot be executed while in spy mode.

See issue 107 https://github.com/bstansell/conserver/issues/107.
